### PR TITLE
Bug fixes for signPsbt

### DIFF
--- a/src/wallet/estimate-wallet.ts
+++ b/src/wallet/estimate-wallet.ts
@@ -171,7 +171,10 @@ export class EstimateWallet implements AbstractWallet {
 
     psbt = await this.keyring.signTransaction(psbt, _inputs);
     if (_opts.autoFinalized) {
-      psbt.finalizeAllInputs();
+      _inputs.forEach((v) => {
+        // psbt.validateSignaturesOfInput(v.index, validator);
+        psbt.finalizeInput(v.index);
+      });
     }
     return psbt;
   }

--- a/src/wallet/local-wallet.ts
+++ b/src/wallet/local-wallet.ts
@@ -200,7 +200,10 @@ export class LocalWallet implements AbstractWallet {
 
     psbt = await this.keyring.signTransaction(psbt, _inputs);
     if (_opts.autoFinalized) {
-      psbt.finalizeAllInputs();
+      _inputs.forEach((v) => {
+        // psbt.validateSignaturesOfInput(v.index, validator);
+        psbt.finalizeInput(v.index);
+      });
     }
     return psbt;
   }


### PR DESCRIPTION
Generally speaking, the input will contain transaction inputs from other addresses, and the original autoFinalized will report an error if it encounters other transaction inputs.
For example.
```signPsbt Error: Can not finalize taproot input #2. No tapleaf script signature provided.```