### PR TITLE
fix: postinstall command

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "build:typed": "tsc --declaration --emitDeclarationOnly --noEmit false",
     "test": "mocha -r ts-node/register test/**/*.ts --timeout 300000",
     "prepublishOnly": "npm run build",
-    "postinstall": "patch-package",
+    "postinstall": "npx patch-package",
     "lint": "eslint ./src ./test"
   },
   "dependencies": {


### PR DESCRIPTION

Failed to install package:

<img width="757" alt="image" src="https://github.com/user-attachments/assets/0f9430ed-b54a-4e8b-ae1c-68d89f3e6139">

## Steps to reproduce:

1. Remove the globally installed `patch-package`

```
pnpm remove -g patch-package
```

2. Clear cache

```
pnpm store prune
```

3. Install `@unisat/wallet-sdk`

```
pnpm i @unisat/wallet-sdk
```

## Solution:

Change `patch-package` to `npx patch-package` to ensure the package can be installed successfully.
