### PR TITLE
fix: update bitcore-lib to v10.8.10 to resolve verifyMessageOfECDSA error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bignumber.js": "^9.1.2",
     "bip39": "^3.1.0",
     "bitcoinjs-lib": "^6.1.6",
-    "bitcore-lib": "^10.0.0",
+    "bitcore-lib": "10.8.10",
     "ecpair": "^2.1.0",
     "hdkey": "^2.1.0",
     "tiny-secp256k1": "=2.2.1"

--- a/src/message/ecdsa.ts
+++ b/src/message/ecdsa.ts
@@ -14,15 +14,11 @@ export function verifyMessageOfECDSA(publicKey: string, text: string, sig: strin
   const hash = message.magicHash();
 
   // recover the public key
-  const ecdsa = new bitcore.crypto.ECDSA();
-  ecdsa.hashbuf = hash;
-  ecdsa.sig = signature;
+  const recoveredPubKey = bitcore.crypto.ECDSA.recoverPublicKey(hash, signature);
 
-  const pubkeyInSig = ecdsa.toPublicKey();
+  const pubkeyInSig = new bitcore.PublicKey(recoveredPubKey.point, { compressed: true });
 
-  const pubkeyInSigString = new bitcore.PublicKey(
-    Object.assign({}, pubkeyInSig.toObject(), { compressed: true })
-  ).toString();
+  const pubkeyInSigString = pubkeyInSig.toString();
   if (pubkeyInSigString != publicKey) {
     return false;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2192,11 +2192,6 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
-bigi@^1.1.0, bigi@^1.4.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/bigi/-/bigi-1.4.2.tgz#9c665a95f88b8b08fc05cfd731f561859d725825"
-  integrity sha512-ddkU+dFIuEIW8lE7ZwdIAf2UPoM90eaprg5m3YXAVVTmKlqV/9BX4A2M8BOK2yOq6/VgZFVhK6QAxJebhlbhzw==
-
 bignumber.js@^9.0.1, bignumber.js@^9.1.2:
   version "9.1.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
@@ -2218,17 +2213,6 @@ bindings@^1.5.0:
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
   dependencies:
     file-uri-to-path "1.0.0"
-
-bip-schnorr@=0.6.4:
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/bip-schnorr/-/bip-schnorr-0.6.4.tgz#6fde7f301fe6b207dbd05f8ec2caf08fa5a51d0d"
-  integrity sha512-dNKw7Lea8B0wMIN4OjEmOk/Z5qUGqoPDY0P2QttLqGk1hmDPytLWW8PR5Pb6Vxy6CprcdEgfJpOjUu+ONQveyg==
-  dependencies:
-    bigi "^1.4.2"
-    ecurve "^1.0.6"
-    js-sha256 "^0.9.0"
-    randombytes "^2.1.0"
-    safe-buffer "^5.2.1"
 
 bip174@^2.1.1:
   version "2.1.1"
@@ -2254,13 +2238,12 @@ bitcoinjs-lib@^6.1.6:
     typeforce "^1.11.3"
     varuint-bitcoin "^1.1.2"
 
-bitcore-lib@^10.0.0:
-  version "10.0.21"
-  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-10.0.21.tgz#3afb32dca7e5843836d608958bac0a057d57b304"
-  integrity sha512-oYB1BrHjeRHqdrZ+j/cVm+M0XGxRDDjDiX4wP9QWQGAZkvS6DQGeNIndwS7m7BA18H76PJRhBM+DrSV2medpXg==
+bitcore-lib@10.8.10:
+  version "10.8.10"
+  resolved "https://registry.yarnpkg.com/bitcore-lib/-/bitcore-lib-10.8.10.tgz#d9db6de95bacc7ce8606eb3b408f3871963bb353"
+  integrity sha512-xk20a40OeL+YAv9hCO8BYbnIdsrX7XyifjGert6kcGrWEz3kjmzfeIkASDZjwn4CE3tbQB9vttvi29unIkizHQ==
   dependencies:
     bech32 "=2.0.0"
-    bip-schnorr "=0.6.4"
     bn.js "=4.11.8"
     bs58 "^4.0.1"
     buffer-compare "=1.1.1"
@@ -3267,14 +3250,6 @@ ecpair@^2.1.0:
     randombytes "^2.1.0"
     typeforce "^1.18.0"
     wif "^2.0.6"
-
-ecurve@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/ecurve/-/ecurve-1.0.6.tgz#dfdabbb7149f8d8b78816be5a7d5b83fcf6de797"
-  integrity sha512-/BzEjNfiSuB7jIWKcS/z8FK9jNjmEWvUV2YZ4RLSmcDtP7Lq0m6FvDuSnJpBlDpGRpfRQeTLGLBI8H+kEv0r+w==
-  dependencies:
-    bigi "^1.1.0"
-    safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.4.601:
   version "1.4.616"
@@ -4758,11 +4733,6 @@ jest-worker@^29.7.0:
     jest-util "^29.7.0"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
-
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This PR addresses the issue described in #26, where users encounter the following error:

```
TypeError: bitcore_lib_1.default.crypto.ECDSA is not a constructor
```

### Root Cause

The issue occurs because bitcore-lib was not version-locked, resulting in users inadvertently installing newer versions of bitcore-lib which introduced breaking changes. Specifically, in recent versions, ECDSA is no longer a constructor function.

### Solution

The PR includes the following fixes:

Locked bitcore-lib to its latest stable version to prevent breaking changes in the future.

Adapted the codebase to accommodate the updated API.

Verified all unit tests pass successfully with the new changes.

### Test

All unit tests are confirmed to be passing after these modifications.